### PR TITLE
Support syntax highlighting for type/interface/enum declarations

### DIFF
--- a/syntaxes/graphql.tmLanguage.json
+++ b/syntaxes/graphql.tmLanguage.json
@@ -133,6 +133,9 @@
           "include": "#variable-type"
         },
         {
+          "include": "#variable-array"
+        },
+        {
           "include": "#variable-bang"
         },
         {
@@ -167,6 +170,19 @@
           "name": "entity.name.type"
         }
       }
+    },
+    "variable-array": {
+      "name": "meta.variable-array.graphql",
+      "begin": "\\[",
+      "end": "\\]",
+      "patterns": [
+        {
+          "include": "#variable-type"
+        },
+        {
+          "include": "#variable-bang"
+        }
+      ]
     },
     "variable-bang": {
       "name": "keyword.operator",

--- a/syntaxes/graphql.tmLanguage.json
+++ b/syntaxes/graphql.tmLanguage.json
@@ -6,6 +6,9 @@
       "include": "#comment"
     },
     {
+      "include": "#type-declaration"
+    },
+    {
       "include": "#operation"
     },
     {
@@ -70,6 +73,57 @@
         },
         "2": {
           "name": "entity.name.function"
+        }
+      }
+    },
+    "type-declaration": {
+      "name": "meta.type-declaration.graphql",
+      "begin": "(type)\\s+([_A-Za-z][_0-9A-Za-z]+)\\s+((@)\\s*([_A-Za-z][_0-9A-Za-z]*))?\\s*\\{",
+      "end": "\\}",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type"
+        },
+        "2": {
+          "name": "entity.name.type"
+        },
+        "4": {
+          "name": "keyword.operator"
+        },
+        "5": {
+          "name": "entity.name.function"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#directive"
+        },
+        {
+          "include": "#arguments"
+        },
+        {
+          "include": "#type-field"
+        },
+        {
+          "include": "#variable-type"
+        },
+        {
+          "include": "#variable-array"
+        },
+        {
+          "include": "#variable-bang"
+        }
+      ]
+    },
+    "type-field": {
+      "name": "entity.section",
+      "match": "[_A-Za-z][_0-9A-Za-z]*(\\s*:)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator"
         }
       }
     },

--- a/syntaxes/graphql.tmLanguage.json
+++ b/syntaxes/graphql.tmLanguage.json
@@ -78,7 +78,7 @@
     },
     "type-declaration": {
       "name": "meta.type-declaration.graphql",
-      "begin": "(type)\\s+([_A-Za-z][_0-9A-Za-z]+)\\s+((@)\\s*([_A-Za-z][_0-9A-Za-z]*))?\\s*\\{",
+      "begin": "(type|interface)\\s+([_A-Za-z][_0-9A-Za-z]+)\\s+((@)\\s*([_A-Za-z][_0-9A-Za-z]*))?\\s*\\{",
       "end": "\\}",
       "beginCaptures": {
         "1": {

--- a/syntaxes/graphql.tmLanguage.json
+++ b/syntaxes/graphql.tmLanguage.json
@@ -72,7 +72,7 @@
       "match": "(@)\\s*([_A-Za-z][_0-9A-Za-z]*)",
       "captures": {
         "1": {
-          "name": "keyword.operator"
+          "name": "entity.name.function"
         },
         "2": {
           "name": "entity.name.function"
@@ -109,7 +109,7 @@
           "name": "entity.name.type"
         },
         "4": {
-          "name": "keyword.operator"
+          "name": "entity.name.function"
         },
         "5": {
           "name": "entity.name.function"

--- a/syntaxes/graphql.tmLanguage.json
+++ b/syntaxes/graphql.tmLanguage.json
@@ -127,7 +127,7 @@
       "end": "\\)",
       "patterns": [
         {
-          "include": "#variable-name"
+          "include": "#variable-declaration"
         },
         {
           "include": "#variable-type"
@@ -146,13 +146,22 @@
         }
       ]
     },
+    "variable-declaration": {
+      "name": "variable.parameter",
+      "match": "\\$[_A-Za-z][_0-9A-Za-z]*(\\s*:)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator"
+        }
+      }
+    },
     "variable-name": {
       "name": "variable.parameter",
       "match": "\\$[_A-Za-z][_0-9A-Za-z]*"
     },
     "variable-type": {
       "name": "meta.variable-type.graphql",
-      "match": ":\\s*([_A-Za-z][_0-9A-Za-z]*)",
+      "match": "([_A-Za-z][_0-9A-Za-z]*)",
       "captures": {
         "1": {
           "name": "entity.name.type"

--- a/syntaxes/graphql.tmLanguage.json
+++ b/syntaxes/graphql.tmLanguage.json
@@ -9,6 +9,9 @@
       "include": "#type-declaration"
     },
     {
+      "include": "#enum-declaration"
+    },
+    {
       "include": "#operation"
     },
     {
@@ -75,6 +78,24 @@
           "name": "entity.name.function"
         }
       }
+    },
+    "enum-declaration": {
+      "name": "meta.enum-declaration.graphql",
+      "begin": "(enum)\\s+([_A-Za-z][_0-9A-Za-z]+)\\s+\\{",
+      "end": "\\}",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type"
+        },
+        "2": {
+          "name": "entity.name.type"
+        }
+      },
+      "patterns": [
+        {
+          "name": "enum"
+        }
+      ]
     },
     "type-declaration": {
       "name": "meta.type-declaration.graphql",


### PR DESCRIPTION
Examples:

<img width="486" alt="screen shot 2018-01-04 at 7 43 06 am" src="https://user-images.githubusercontent.com/2320890/34566093-f06962aa-f122-11e7-85dc-604ce5ada130.png">
<img width="468" alt="screen shot 2018-01-04 at 7 41 49 am" src="https://user-images.githubusercontent.com/2320890/34566094-f0768fde-f122-11e7-85ac-6284c2bb6ec6.png">


Closes #4.
  