### PR TITLE
Support nodejs v7.7.0+ debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ Example:
 ```
 
 See [here](https://github.com/graphcool/graphql-config#usage) for other ways to provide a GraphQL schema.
+
+## Developing
+
+### Debugging `graphql-language-service`
+
+The language service is run, and debugged, as a standalone Node.js process. See [Node.js debugging guide](https://nodejs.org/en/docs/guides/debugging-getting-started/) for general information.
+
+The simplest way to debug is to open chrome://inspect in Chrome and browse for the process. Alternatively in the test target VSCode (i.e. where the extension is running) toggle View → Output and follow the printed instructions.

--- a/lib/client/extension.ts
+++ b/lib/client/extension.ts
@@ -43,7 +43,9 @@ export function activate(context: ExtensionContext) {
     path.join("bin/server", "server.js"),
   );
 
-  let debugOptions = { execArgv: ["--nolazy", "--debug=6009"] };
+  let debugOptions = {
+    execArgv: ["--nolazy", "--debug=6009", "--inspect=localhost:6009"],
+  };
 
   let serverOptions: ServerOptions = {
     run: { module: serverModule, transport: TransportKind.ipc },


### PR DESCRIPTION
- Add `--inspect` command flag
- Leave `--debug` in place for compatibility with pre-7.7.0

See https://nodejs.org/en/docs/guides/debugging-getting-started/

Fix for https://github.com/stephen/vscode-graphql/issues/13