### PR TITLE
Bump graphql-language-service-server dependency version to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "graphql": "^0.12.3 || ^0.11.7",
-    "graphql-language-service-server": "^1.1.1",
+    "graphql-language-service-server": "^1.1.2",
     "vscode": "^1.1.10",
     "vscode-languageclient": "^3.5.0",
     "vscode-languageserver": "^3.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,9 +620,9 @@ graphql-language-service-parser@^1.1.0:
     graphql-config "1.1.4"
     graphql-language-service-types "^1.1.0"
 
-graphql-language-service-server@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/graphql-language-service-server/-/graphql-language-service-server-1.1.1.tgz#311a8d4ee82e23e050643900f0fd01da8fc11a54"
+graphql-language-service-server@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/graphql-language-service-server/-/graphql-language-service-server-1.1.2.tgz#a4ec588e9e5a57087bfc264f55b7f61ccf925f6c"
   dependencies:
     babylon "^6.17.4"
     fb-watchman "^2.0.0"


### PR DESCRIPTION
v1.1.2 of `graphql/graphql-language-service` fixes issues which occur when the `includes` key in `.graphqlconfig` is missing, empty, or contains non-glob-like paths to files that don't exist.